### PR TITLE
WIP: Added more joints wrappers and draft demo for it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "de.fabmax.kool"
-    version = "0.9.0-SNAPSHOT"
+    version = "0.9.1-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/Demo.kt
+++ b/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/Demo.kt
@@ -7,6 +7,7 @@ import de.fabmax.kool.demo.atmosphere.AtmosphereDemo
 import de.fabmax.kool.demo.pbr.PbrDemo
 import de.fabmax.kool.demo.physics.collision.CollisionDemo
 import de.fabmax.kool.demo.physics.joints.JointsDemo
+import de.fabmax.kool.demo.physics.joints.PendulumDemo
 import de.fabmax.kool.demo.physics.manyvehicles.ManyVehiclesDemo
 import de.fabmax.kool.demo.physics.ragdoll.RagdollDemo
 import de.fabmax.kool.demo.physics.terrain.TerrainDemo
@@ -56,6 +57,7 @@ class Demo(ctx: KoolContext, startScene: String? = null, extraScenes: List<DemoE
         "phys-ragdoll" to DemoEntry("Physics - Ragdoll") { RagdollDemo() },
         "phys-vehicle" to DemoEntry("Physics - Vehicle") { VehicleDemo() },
         "phys-joints" to DemoEntry("Physics - Joints") { JointsDemo() },
+        "phys-pen" to DemoEntry("Physics - Pendulums") { PendulumDemo() },
         "physics" to DemoEntry("Physics - Collision") { CollisionDemo() },
         "atmosphere" to DemoEntry("Atmospheric Scattering") { AtmosphereDemo() },
         "procedural" to DemoEntry("Procedural Geometry") { ProceduralDemo() },

--- a/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/collision/CollisionDemo.kt
+++ b/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/collision/CollisionDemo.kt
@@ -53,9 +53,9 @@ class CollisionDemo : DemoScene("Physics - Collision") {
         groundNormal = loadAndPrepareTexture("${Demo.materialPath}/tile_flat/tiles_flat_fine_normal.png")
 
         Physics.awaitLoaded()
-        val physicsWorld = PhysicsWorld()
-        this@CollisionDemo.physicsWorld = physicsWorld
-        physicsWorld.simStepper = physicsStepper
+        this@CollisionDemo.physicsWorld = PhysicsWorld().apply {
+            simStepper = physicsStepper
+        }
     }
 
     override fun Scene.setupMainScene(ctx: KoolContext) {

--- a/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/joints/PendulumDemo.kt
+++ b/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/joints/PendulumDemo.kt
@@ -1,0 +1,142 @@
+package de.fabmax.kool.demo.physics.joints
+
+import de.fabmax.kool.AssetManager
+import de.fabmax.kool.KoolContext
+import de.fabmax.kool.demo.Cycler
+import de.fabmax.kool.demo.Demo
+import de.fabmax.kool.demo.DemoScene
+import de.fabmax.kool.math.*
+import de.fabmax.kool.physics.*
+import de.fabmax.kool.physics.geometry.PlaneGeometry
+import de.fabmax.kool.physics.geometry.SphereGeometry
+import de.fabmax.kool.physics.joints.DistanceJoint
+import de.fabmax.kool.physics.joints.Joint
+import de.fabmax.kool.physics.joints.RevoluteJoint
+import de.fabmax.kool.pipeline.Texture2d
+import de.fabmax.kool.pipeline.shading.pbrShader
+import de.fabmax.kool.scene.*
+import de.fabmax.kool.util.Color
+import de.fabmax.kool.util.MdColor
+import kotlin.math.PI
+
+class PendulumDemo : DemoScene("Physics - Pendulum") {
+    private val physicsWorld by lazy { PhysicsWorld().also {
+        it.simStepper = SimplePhysicsStepper()
+    } }
+
+    private val ground by lazy { RigidStatic().also {
+        it.simulationFilterData = staticSimFilterData
+        it.attachShape(Shape(PlaneGeometry(), material))
+        it.position = Vec3f(0f, -20f, 0f)
+        it.setRotation(Mat3f().rotate(90f, Vec3f.Z_AXIS))
+    } }
+
+    private var motorGearConstraint: RevoluteJoint? = null
+    private var motorStrength = 50f
+    private var motorSpeed = 1.5f
+    private var motorDirection = 1f
+
+    private val staticCollGroup = 1
+    private val staticSimFilterData = FilterData {
+        setCollisionGroup(staticCollGroup)
+        clearCollidesWith(staticCollGroup)
+    }
+
+    private val joints = mutableListOf<Joint>()
+
+    private val material = Material(0.0f)
+    private lateinit var groundAlbedo: Texture2d
+    private lateinit var groundNormal: Texture2d
+    override suspend fun AssetManager.loadResources(ctx: KoolContext) {
+        Physics.awaitLoaded()
+        groundAlbedo = loadAndPrepareTexture("${Demo.pbrBasePath}/tile_flat/tiles_flat_fine.png")
+        groundNormal = loadAndPrepareTexture("${Demo.pbrBasePath}/tile_flat/tiles_flat_fine_normal.png")
+
+        physicsWorld.registerHandlers(mainScene)
+    }
+
+    override fun Scene.setupMainScene(ctx: KoolContext) {
+        setupCamera()
+        lighting.singleLight {
+            setDirectional(Vec3f(0.8f, -1.2f, 1f))
+        }
+
+        physicsWorld.apply {
+            addActor(ground)
+        }
+
+        // ground plane
+        mainScene += textureMesh(isNormalMapped = true) {
+            isCastingShadow = false
+            generate {
+                rotate(-90f, Vec3f.X_AXIS)
+                rect {
+                    size.set(250f, 250f)
+                    origin.set(-size.x * 0.5f, -size.y * 0.5f, -20f)
+                    generateTexCoords(15f)
+                }
+            }
+            shader = pbrShader {
+                useAlbedoMap(groundAlbedo)
+                useNormalMap(groundNormal)
+                //useScreenSpaceAmbientOcclusion(aoPipeline.aoMap)
+                //useImageBasedLighting(ibl)
+                //shadowMaps += shadows
+            }
+        }
+        mainScene += physicsWorld.generatePendulum(joints = joints)
+    }
+
+    private fun Scene.setupCamera() {
+        defaultCamTransform().apply {
+            setMouseRotation(-20f, -20f)
+            zoom = 50.0
+            maxZoom = 200.0
+        }
+        (camera as PerspectiveCamera).apply {
+            clipNear = 1f
+            clipFar = 1000f
+        }
+    }
+
+    private fun PhysicsWorld.generatePendulum(bodies: Int = 10, segmentLength: Float = 1.9f, joints: MutableList<Joint>) = group {
+        val minAng = -90f
+        val maxAng = 90f
+        val pin = RigidStatic().apply {
+            attachShape(Shape(SphereGeometry(0.2f), material))
+        }
+
+        addActor(pin)
+        +pin.toMesh(Color.WHITE)
+        var prevNode: RigidActor = pin
+
+        for ( i in 0 until bodies) {
+            val mass = (bodies - i) * 5f
+            val pos = MutableVec3f(0f, segmentLength, 0f)
+
+            pos.rotate(randomF(minAng, maxAng), Vec3f.X_AXIS)
+            pos.rotate(randomF(minAng, maxAng), Vec3f.Z_AXIS)
+
+            val pong = RigidDynamic(mass).apply {
+                attachShape(Shape(SphereGeometry(0.2f), material))
+                position = add(prevNode.position, pos)
+            }
+
+            addActor(pong)
+            +pong.toMesh(colorMap.next())
+
+            joints.add(DistanceJoint(prevNode, pong, Mat4f(), Mat4f()).apply {
+                setMaxDistance(segmentLength)
+                debugVisualize = true
+
+            })
+            prevNode = pong
+        }
+    }
+
+    private val colorMap = Cycler(listOf(
+            MdColor.RED, MdColor.PINK, MdColor.PURPLE, MdColor.DEEP_PURPLE,
+            MdColor.INDIGO, MdColor.BLUE, MdColor.LIGHT_BLUE, MdColor.CYAN, MdColor.TEAL, MdColor.GREEN,
+            MdColor.LIGHT_GREEN, MdColor.LIME, MdColor.YELLOW, MdColor.AMBER, MdColor.ORANGE, MdColor.DEEP_ORANGE))
+        .apply { index = 1 }
+}

--- a/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/joints/PendulumDemo.kt
+++ b/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/joints/PendulumDemo.kt
@@ -7,9 +7,7 @@ import de.fabmax.kool.demo.Demo
 import de.fabmax.kool.demo.DemoScene
 import de.fabmax.kool.math.*
 import de.fabmax.kool.physics.*
-import de.fabmax.kool.physics.geometry.BoxGeometry
-import de.fabmax.kool.physics.geometry.PlaneGeometry
-import de.fabmax.kool.physics.geometry.SphereGeometry
+import de.fabmax.kool.physics.geometry.*
 import de.fabmax.kool.physics.joints.*
 import de.fabmax.kool.pipeline.Texture2d
 import de.fabmax.kool.pipeline.shading.pbrShader
@@ -17,6 +15,7 @@ import de.fabmax.kool.scene.*
 import de.fabmax.kool.util.Color
 import de.fabmax.kool.util.MdColor
 import kotlin.math.PI
+import kotlin.math.ceil
 
 class PendulumDemo : DemoScene("Physics - Pendulum") {
     private val physicsWorld by lazy { PhysicsWorld().also {
@@ -54,7 +53,10 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
 
     private val pendulums = mutableListOf<Pendulum>()
     private val springs by lazy {
-        Springs(world = physicsWorld)
+        Springs(world = physicsWorld, origin = Vec3f(-20f, 0f, -20f))
+    }
+    private val chainRoller by lazy {
+        ChainRoller(origin = Vec3f(20f, 10f, -20f))
     }
 
     override fun Scene.setupMainScene(ctx: KoolContext) {
@@ -157,6 +159,9 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
 
         mainScene += springs
         springs.start()
+
+        mainScene += chainRoller
+        chainRoller.start(physicsWorld)
     }
 
     override fun dispose(ctx: KoolContext) {
@@ -210,11 +215,6 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
             MdColor.LIGHT_GREEN, MdColor.LIME, MdColor.YELLOW, MdColor.AMBER, MdColor.ORANGE, MdColor.DEEP_ORANGE))
             .apply { index = 1 }
 
-        // chaingenerator -
-        // interface ChainGenerator {
-        // firstNode
-        // on edge
-        // on node
         init {
             actors.add(pin)
             +pin.toMesh(Color.WHITE)
@@ -239,6 +239,8 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
                 joints.add(makeEdge(prevNode, pong))
                 prevNode = pong
             }
+
+            children.last().addDebugAxis()
         }
 
         fun start() = expose()
@@ -260,6 +262,7 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
     }
 
     class Springs(val world: PhysicsWorld,
+                  private val origin: Vec3f = Vec3f(0f, 0f, 0f),
                   private val dy: Float = 1.5f,
                   private val totalHeight: Float = 20f,
                   private val pinHeight: Float = 5f,
@@ -276,7 +279,7 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
 
                 for ( dm in 0 until n ) {
                     val realDamp = dm / n.toFloat()
-                    val initPos = Mat4f().translate(- dy * (st+1), totalHeight, - dy * (dm + 1))
+                    val initPos = Mat4f().translate(origin).translate(- dy * (st+1), totalHeight, - dy * (dm + 1))
                     val basement = RigidStatic(initPos.rotate(90f, Vec3f.X_AXIS)).apply {
                         attachShape(Shape(BoxGeometry(Vec3f(0.5f, 0.5f, 0.2f)), bodyMaterial))
                     }
@@ -313,17 +316,149 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
         }
 
     }
+
+    class ChainRoller(val origin: Vec3f = Vec3f(10f, 10f, -10f),
+                      val shaftRadius: Float = 1f,
+                      val shaftWidth: Float = 5f,
+                      val n: Int = 20, // between end and start of semi-circled parts
+                      val chainSegmentLength: Float = 1f,         // 1 chain segment length
+                      val chainSegmentSize: Float = 0.5f,
+                      val chainMass: Float = 10f,
+    ): Group() {
+        val pin = RigidStatic(Mat4f().translate(origin)).apply {
+            attachShape(Shape(BoxGeometry(Vec3f(0.3f))))
+        }
+
+        val disk = RigidDynamic(1f).apply {
+            // TBD rework
+            attachShape(Shape(
+                geometry = CylinderGeometry(shaftWidth, shaftRadius),
+                localPose = Mat4f().rotate(90f, Vec3f.Y_AXIS)
+            ))
+            attachShape(Shape(
+                geometry = CylinderGeometry(1f, shaftRadius + chainSegmentSize * 5),
+                localPose = Mat4f().translate(0f, 0f, shaftWidth/2f).rotate(90f, Vec3f.Y_AXIS)
+            ))
+            attachShape(Shape(
+                geometry = CylinderGeometry(1f, shaftRadius + chainSegmentSize * 5),
+                localPose = Mat4f().translate(0f, 0f, -shaftWidth/2f).rotate(-90f, Vec3f.Y_AXIS)
+            ))
+        }
+
+        private var diskJoint: Joint? = RevoluteJoint(pin, disk,
+            Mat4f().rotate(90f, Vec3f.Y_AXIS),
+            Mat4f().rotate(-90f, Vec3f.Y_AXIS)).apply {
+            enableAngularMotor(1f, 100f)
+        }
+
+        val chains = mutableListOf<RigidActor>()
+        val joints = mutableListOf<Joint>()
+
+        lateinit var world: PhysicsWorld
+
+        init {
+            + pin.toMesh(Color.RED)
+            + disk.toMesh(Color.GREEN)
+
+            // logo time
+            val halfCircleChains = ceil(PI * shaftRadius / chainSegmentLength).toInt()
+            val angleStep = (PI / halfCircleChains.toFloat()).toDeg().toFloat()
+            if ( halfCircleChains < 3 ) {
+                println("warning shaftRadius too small $shaftRadius")
+            }
+
+            for ( c in 0 .. halfCircleChains ) {
+                val r = MutableVec3f( shaftRadius + chainSegmentSize, 0f, 0f)
+                r.rotate(c * angleStep, Vec3f.Z_AXIS, r)
+                chains.add(RigidDynamic(chainMass, Mat4f().translate(origin).translate(r)).apply {
+                    attachShape(Shape(SphereGeometry(chainSegmentSize)))
+                })
+            }
+
+            for ( c in 1 until n ) {
+                val pos = Mat4f().translate(origin).translate( -shaftRadius - chainSegmentSize, -c * chainSegmentLength, 0f)
+                chains.add(RigidDynamic(chainMass, pos).apply {
+                    attachShape(Shape(SphereGeometry(chainSegmentSize)))
+                })
+            }
+
+            for ( c in 0 .. halfCircleChains ) {
+                val r = MutableVec3f( -shaftRadius - chainSegmentSize, 0f, 0f)
+                r.rotate(c * angleStep, Vec3f.Z_AXIS, r)
+                val pos = Mat4f().translate(origin).translate(0f, -n * chainSegmentLength, 0f).translate(r)
+                chains.add(RigidDynamic(chainMass, pos).apply {
+                    attachShape(Shape(SphereGeometry(chainSegmentSize)))
+                })
+            }
+
+            for ( c in 1 until n ) {
+                val pos = Mat4f().translate(origin).translate(shaftRadius + chainSegmentSize, -c * chainSegmentLength, 0f)
+                chains.add(RigidDynamic(chainMass, pos).apply {
+                    attachShape(Shape(SphereGeometry(chainSegmentSize)))
+                })
+            }
+
+            chains.fold(chains.first()) { prev, current ->
+                joints.add(DistanceJoint(prev, current, Mat4f(), Mat4f()).apply {
+                    setMaxDistance(chainSegmentLength)
+                    setMinDistance(chainSegmentLength)
+                })
+                current
+            }
+            joints.add(DistanceJoint(chains.first(), chains.last(), Mat4f(), Mat4f()).apply {
+                setMaxDistance(chainSegmentLength)
+                setMinDistance(chainSegmentLength)
+            })
+
+            chains.forEach {
+                +it.toMesh(Color.LIGHT_YELLOW).also {
+                    it.addDebugAxis()
+                }
+            }
+        }
+
+        fun start(world: PhysicsWorld) {
+            this.world = world
+            world.addActor(pin)
+            world.addActor(disk)
+            chains.forEach {
+                world.addActor(it)
+            }
+        }
+
+        override fun dispose(ctx: KoolContext) {
+            if ( !::world.isInitialized ) return
+
+            world.removeActor(pin)
+            world.removeActor(disk)
+            chains.forEach { world.removeActor(it) }
+            chains.clear()
+            joints.forEach { it.dispose(ctx) }
+            joints.clear()
+        }
+    }
 }
 
+fun Node.parentGroup(): Group {
+    return when {
+        this is Group -> this
+        this.parent != null -> this.parent!!.parentGroup()
+        else -> throw RuntimeException("no parent group $this")
+    }
+}
 
-fun Group.addDebugAxis() {
-//    val x = lineMesh("x") { addLine(Vec3f.ZERO, Vec3f(1f, 0f, 0f), Color.RED) }
-//    +x
-//    +lineMesh("y") { addLine(Vec3f.ZERO, Vec3f(0f, 1f, 0f), Color.GREEN) }
-//    +lineMesh("z") { addLine(Vec3f.ZERO, Vec3f(0f, 0f, 1f), Color.BLUE) }
-//    onUpdate += {
-//        x.transform.set(this@CommonRigidActor.transform)
-//            this@group.setDirty()
-//
-//    }
+fun Node.addDebugAxis() {
+    with(parentGroup()) {
+        val x = lineMesh("x") { addLine(Vec3f.ZERO, Vec3f(1f, 0f, 0f), Color.RED) }
+        val y = lineMesh("y") { addLine(Vec3f.ZERO, Vec3f(0f, 1f, 0f), Color.GREEN) }
+        val z = lineMesh("z") { addLine(Vec3f.ZERO, Vec3f(0f, 0f, 1f), Color.BLUE) }
+        +x
+        +y
+        +z
+        onUpdate += {
+            x.modelMat.set(this@addDebugAxis.modelMat)
+            y.modelMat.set(this@addDebugAxis.modelMat)
+            z.modelMat.set(this@addDebugAxis.modelMat)
+        }
+    }
 }

--- a/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/joints/PendulumDemo.kt
+++ b/kool-demo/src/commonMain/kotlin/de/fabmax/kool/demo/physics/joints/PendulumDemo.kt
@@ -9,15 +9,12 @@ import de.fabmax.kool.math.*
 import de.fabmax.kool.physics.*
 import de.fabmax.kool.physics.geometry.PlaneGeometry
 import de.fabmax.kool.physics.geometry.SphereGeometry
-import de.fabmax.kool.physics.joints.DistanceJoint
-import de.fabmax.kool.physics.joints.Joint
-import de.fabmax.kool.physics.joints.RevoluteJoint
+import de.fabmax.kool.physics.joints.*
 import de.fabmax.kool.pipeline.Texture2d
 import de.fabmax.kool.pipeline.shading.pbrShader
 import de.fabmax.kool.scene.*
 import de.fabmax.kool.util.Color
 import de.fabmax.kool.util.MdColor
-import kotlin.math.PI
 
 class PendulumDemo : DemoScene("Physics - Pendulum") {
     private val physicsWorld by lazy { PhysicsWorld().also {
@@ -42,24 +39,23 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
         clearCollidesWith(staticCollGroup)
     }
 
-    private val joints = mutableListOf<Joint>()
-
     private val material = Material(0.0f)
     private lateinit var groundAlbedo: Texture2d
     private lateinit var groundNormal: Texture2d
     override suspend fun AssetManager.loadResources(ctx: KoolContext) {
         Physics.awaitLoaded()
-        groundAlbedo = loadAndPrepareTexture("${Demo.pbrBasePath}/tile_flat/tiles_flat_fine.png")
-        groundNormal = loadAndPrepareTexture("${Demo.pbrBasePath}/tile_flat/tiles_flat_fine_normal.png")
+        groundAlbedo = loadAndPrepareTexture("${Demo.materialPath}/tile_flat/tiles_flat_fine.png")
+        groundNormal = loadAndPrepareTexture("${Demo.materialPath}/tile_flat/tiles_flat_fine_normal.png")
 
         physicsWorld.registerHandlers(mainScene)
     }
 
+    private var pendulums = mutableListOf<Pendulum>()
+
     override fun Scene.setupMainScene(ctx: KoolContext) {
+
         setupCamera()
-        lighting.singleLight {
-            setDirectional(Vec3f(0.8f, -1.2f, 1f))
-        }
+        setupLighting()
 
         physicsWorld.apply {
             addActor(ground)
@@ -84,7 +80,86 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
                 //shadowMaps += shadows
             }
         }
-        mainScene += physicsWorld.generatePendulum(joints = joints)
+
+        pendulums.add(Pendulum(physicsWorld).also {
+            it.start()
+            mainScene += it
+        })
+
+        val dy = 1.5f
+        var y = dy
+        val radius = 0.3f
+        val segmentLength = 2f
+
+        pendulums.add( Pendulum(physicsWorld,
+            bodies = 4,
+            bodyMaterial = Material(0.5f),
+            translate = Vec3f(0f, 2f, 6f),
+            segmentLength = segmentLength,
+            makeEdge = { prevNode, node ->
+                //SphericalJoint(prevNode, node,
+                FixedJoint(prevNode, node,
+                    Mat4f().translate(0f, -segmentLength/2,  0f, /*  + segmentLength/2f*/),
+                    Mat4f().translate( 0f, segmentLength/2, 0f, /* - segmentLength/2f*/)
+                ).also {
+                    //it.setSoftLimitCone((PI/4f).toFloat(), (PI/4f).toFloat(), 100f, 100f)
+                }
+            }
+        ).also {
+            mainScene += it
+            it.start()
+        } )
+        y += dy
+
+        pendulums.add( Pendulum(physicsWorld,
+            translate = Vec3f(y, 0f, 0f),
+            makeEdge = { p, n ->
+                D6Joint(p, n,
+                    Mat4f().translate(0f, -0.21f, 0f),
+                    Mat4f().translate(0f, 0.21f, 0f)).also {
+                    it.motionX = D6JointMotion.Locked
+                    it.motionY = D6JointMotion.Locked
+                    it.motionZ = D6JointMotion.Locked
+                }
+            }
+        ).also {
+            it.start()
+            mainScene += it
+        })
+        y += dy
+
+        pendulums.add( Pendulum(physicsWorld,
+            translate = Vec3f(y, 0f, 0f),
+            segmentLength = 1f,
+            makeEdge = { p, n ->
+                val minBounds = MutableVec3f(p.worldBounds.min).also {
+                    it -=p.worldBounds.center
+                }
+
+                val maxBounds = MutableVec3f(p.worldBounds.max).also {
+                    it -= p.worldBounds.center
+                }
+                D6Joint(p, n,
+                    Mat4f().translate(0f, minBounds.y, 0f),
+                    Mat4f().translate(0f, maxBounds.y, 0f)).also {
+                    it.motionX = D6JointMotion.Free
+                    it.motionY = D6JointMotion.Limited
+                    it.motionZ = D6JointMotion.Limited
+                    it.setDistanceLimit(0.5f, 10f, 10f)
+                }
+            }
+        ).also {
+            it.start()
+            mainScene += it
+        })
+        y += dy
+
+        //ctx.inputMgr.registerKeyListener()
+    }
+
+    override fun dispose(ctx: KoolContext) {
+        super.dispose(ctx)
+        pendulums.forEach { it.dispose(ctx) }
     }
 
     private fun Scene.setupCamera() {
@@ -99,44 +174,99 @@ class PendulumDemo : DemoScene("Physics - Pendulum") {
         }
     }
 
-    private fun PhysicsWorld.generatePendulum(bodies: Int = 10, segmentLength: Float = 1.9f, joints: MutableList<Joint>) = group {
-        val minAng = -90f
-        val maxAng = 90f
-        val pin = RigidStatic().apply {
-            attachShape(Shape(SphereGeometry(0.2f), material))
-        }
-
-        addActor(pin)
-        +pin.toMesh(Color.WHITE)
-        var prevNode: RigidActor = pin
-
-        for ( i in 0 until bodies) {
-            val mass = (bodies - i) * 5f
-            val pos = MutableVec3f(0f, segmentLength, 0f)
-
-            pos.rotate(randomF(minAng, maxAng), Vec3f.X_AXIS)
-            pos.rotate(randomF(minAng, maxAng), Vec3f.Z_AXIS)
-
-            val pong = RigidDynamic(mass).apply {
-                attachShape(Shape(SphereGeometry(0.2f), material))
-                position = add(prevNode.position, pos)
-            }
-
-            addActor(pong)
-            +pong.toMesh(colorMap.next())
-
-            joints.add(DistanceJoint(prevNode, pong, Mat4f(), Mat4f()).apply {
-                setMaxDistance(segmentLength)
-                debugVisualize = true
-
-            })
-            prevNode = pong
+    private fun Scene.setupLighting() {
+        lighting.singleLight {
+            setDirectional(Vec3f(0.8f, -1.2f, 1f))
         }
     }
 
-    private val colorMap = Cycler(listOf(
+    class Pendulum(val world: PhysicsWorld,
+                   private val bodies: Int = 10,
+                   private val bodyRadius: Float = 0.2f,
+                   private val bodyMaterial: Material = Material(0f, 0f, 0f),
+                   private val segmentLength: Float = 1.9f,
+                   private val translate: Vec3f = Vec3f.ZERO,
+                   val makeEdge: Pendulum.(prevNode: RigidActor, node: RigidActor) -> Joint = { prevNode, node ->
+                             DistanceJoint(prevNode, node, Mat4f(), Mat4f()).apply {
+                             setMaxDistance(segmentLength)
+                             debugVisualize = true
+                         } }
+    ) : Group("double pendulum root") {
+        private val actors = mutableListOf<RigidActor>()
+        private val joints = mutableListOf<Joint>()
+
+        private val nextRandomAngle get() = randomF(-60f, 60f)
+
+        val pin by lazy { RigidStatic().apply {
+            translate(translate)
+            attachShape(Shape(SphereGeometry(bodyRadius), bodyMaterial))
+        } }
+
+        private val colorMap = Cycler(listOf(
             MdColor.RED, MdColor.PINK, MdColor.PURPLE, MdColor.DEEP_PURPLE,
             MdColor.INDIGO, MdColor.BLUE, MdColor.LIGHT_BLUE, MdColor.CYAN, MdColor.TEAL, MdColor.GREEN,
             MdColor.LIGHT_GREEN, MdColor.LIME, MdColor.YELLOW, MdColor.AMBER, MdColor.ORANGE, MdColor.DEEP_ORANGE))
-        .apply { index = 1 }
+            .apply { index = 1 }
+
+        // chaingenerator -
+        // interface ChainGenerator {
+        // firstNode
+        // on edge
+        // on node
+        init {
+            actors.add(pin)
+            +pin.toMesh(Color.WHITE)
+            var prevNode: RigidActor = pin
+
+            for ( i in 0 until bodies) {
+                val mass = (i + 1) * 5f
+                val pos = MutableVec3f(0f, segmentLength, 0f)
+
+                pos.rotate(nextRandomAngle, Vec3f.X_AXIS)
+                pos.rotate(nextRandomAngle, Vec3f.Z_AXIS)
+
+                val pong = RigidDynamic(mass).apply {
+                    attachShape(Shape(SphereGeometry(bodyRadius), bodyMaterial))
+                    position = add(prevNode.position, pos)
+                    translate(translate)
+                }
+
+                actors.add(pong)
+                +pong.toMesh(colorMap.next())
+
+                joints.add(makeEdge(prevNode, pong))
+                prevNode = pong
+            }
+        }
+
+        fun start() = expose()
+        fun stop(ctx: KoolContext) = dispose(ctx)
+
+        fun expose() {
+            actors.forEach { world.addActor(it) }
+        }
+
+        override fun dispose(ctx: KoolContext) {
+            super.dispose(ctx)
+            actors.forEach { world.removeActor(it); } // stop
+
+            joints.forEach { it.dispose(ctx) }
+            actors.forEach { it.dispose(ctx) }
+            actors.clear()
+            joints.clear()
+        }
+    }
+}
+
+
+fun Group.addDebugAxis() {
+//    val x = lineMesh("x") { addLine(Vec3f.ZERO, Vec3f(1f, 0f, 0f), Color.RED) }
+//    +x
+//    +lineMesh("y") { addLine(Vec3f.ZERO, Vec3f(0f, 1f, 0f), Color.GREEN) }
+//    +lineMesh("z") { addLine(Vec3f.ZERO, Vec3f(0f, 0f, 1f), Color.BLUE) }
+//    onUpdate += {
+//        x.transform.set(this@CommonRigidActor.transform)
+//            this@group.setDirty()
+//
+//    }
 }

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
@@ -17,7 +17,6 @@ expect class D6Joint(bodyA: RigidActor, bodyB: RigidActor, posA: Mat4f, posB: Ma
     val frameA: Mat4f
     val frameB: Mat4f
 
-
     var projectionLinearTolerance: Float?
 
     var motionX: D6JointMotion

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
@@ -1,0 +1,30 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.RigidActor
+
+// public aliases of PhysX
+expect enum class D6JointMotion {
+    Free,
+    Limited,
+    Locked
+}
+
+expect class D6Joint(bodyA: RigidActor, bodyB: RigidActor, posA: Mat4f, posB: Mat4f) : Joint {
+    val bodyA: RigidActor
+    val bodyB: RigidActor
+
+    val frameA: Mat4f
+    val frameB: Mat4f
+
+
+    var projectionLinearTolerance: Float?
+
+    var motionX: D6JointMotion
+    var motionY: D6JointMotion
+    var motionZ: D6JointMotion
+    fun setDistanceLimit(extend: Float, stiffness: Float, damping: Float)
+    fun setXLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float)
+    fun setYLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float)
+    fun setZLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float)
+}

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/DistanceJoint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/DistanceJoint.kt
@@ -1,0 +1,16 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.RigidActor
+
+expect class DistanceJoint(bodyA: RigidActor, bodyB: RigidActor, posA: Mat4f, posB: Mat4f) : Joint {
+    val bodyA: RigidActor
+    val bodyB: RigidActor
+
+    val frameA: Mat4f
+    val frameB: Mat4f
+    fun setMaxDistance(maxDistance: Float)
+    fun setMinDistance(minDistance: Float)
+    fun removeMaxDistance()
+    fun removeMinDistance()
+}

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
@@ -2,10 +2,12 @@ package de.fabmax.kool.physics.joints
 
 import de.fabmax.kool.physics.Releasable
 
-expect interface Joint : Releasable {
+expect abstract class Joint : Releasable {
 
     val isBroken: Boolean
+    var debugVisualize: Boolean
 
     fun setBreakForce(force: Float, torque: Float)
+
 
 }

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
@@ -8,6 +8,4 @@ expect abstract class Joint : Releasable {
     var debugVisualize: Boolean
 
     fun setBreakForce(force: Float, torque: Float)
-
-
 }

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/PrismaticJoint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/PrismaticJoint.kt
@@ -1,0 +1,11 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.RigidActor
+
+expect class PrismaticJoint(bodyA: RigidActor, bodyB: RigidActor, posA: Mat4f, posB: Mat4f) : Joint {
+    val frameA: Mat4f
+    val frameB: Mat4f
+    fun setLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float)
+    fun removeLimit()
+}

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/RevoluteJoint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/RevoluteJoint.kt
@@ -6,7 +6,7 @@ import de.fabmax.kool.math.MutableVec3f
 import de.fabmax.kool.math.Vec3f
 import de.fabmax.kool.physics.RigidActor
 
-expect class RevoluteJoint(bodyA: RigidActor, bodyB: RigidActor, frameA: Mat4f, frameB: Mat4f) : CommonRevoluteJoint, Joint {
+expect class RevoluteJoint(bodyA: RigidActor, bodyB: RigidActor, frameA: Mat4f, frameB: Mat4f) : Joint {
     val bodyA: RigidActor
     val bodyB: RigidActor
 

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
@@ -1,0 +1,16 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.RigidActor
+
+expect class SphericalJoint(bodyA: RigidActor, bodyB: RigidActor, posA: Mat4f, posB: Mat4f): Joint {
+    val bodyA: RigidActor
+    val bodyB: RigidActor
+
+    val frameA: Mat4f
+    val frameB: Mat4f
+//    fun setHardLimitCone(yLimitAngle: Float, zLimitAngle: Float, contactDist: Float = -1.0f)
+
+    fun setSoftLimitCone(yLimitAngle: Float, zLimitAngle: Float, stiffness: Float, damping: Float)
+    fun removeLimitCone()
+}

--- a/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
+++ b/kool-physics/src/commonMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
@@ -3,6 +3,11 @@ package de.fabmax.kool.physics.joints
 import de.fabmax.kool.math.Mat4f
 import de.fabmax.kool.physics.RigidActor
 
+/**
+ * This is also known as a ball-socket joint.
+ * It doesn't allow linear movement along the joint, but allows the orientation to vary freely.
+ * An adjustable mirror connected to a vehicle is a good example of a spherical joint.
+ */
 expect class SphericalJoint(bodyA: RigidActor, bodyB: RigidActor, posA: Mat4f, posB: Mat4f): Joint {
     val bodyA: RigidActor
     val bodyB: RigidActor

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
@@ -1,0 +1,87 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.MemoryStack
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.toPxTransform
+import physx.*
+
+actual enum class D6JointMotion(val pxVal: Int) {
+    Free(PxD6MotionEnum.eFREE),
+    Limited(PxD6MotionEnum.eLIMITED),
+    Locked(PxD6MotionEnum.eLOCKED);
+
+    companion object {
+        fun fromPx(pxVal: Int) = when (pxVal) {
+            PxD6MotionEnum.eFREE -> D6JointMotion.Free
+            PxD6MotionEnum.eLIMITED -> D6JointMotion.Limited
+            PxD6MotionEnum.eLOCKED -> D6JointMotion.Locked
+            else -> throw RuntimeException()
+        }
+    }
+}
+
+actual class D6Joint actual constructor(
+    actual val bodyA: RigidActor,
+    actual val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+
+    actual var projectionLinearTolerance: Float? = null
+        set(value) = if (value != null) {
+            pxJoint.projectionLinearTolerance = value
+            pxJoint.constraintFlags.set(PxConstraintFlagEnum.ePROJECTION)
+        } else {
+            pxJoint.constraintFlags.clear(PxConstraintFlagEnum.ePROJECTION)
+        }
+
+    override val pxJoint: PxD6Joint
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = frameA.toPxTransform(mem.createPxTransform())
+            val frmB = frameB.toPxTransform(mem.createPxTransform())
+            pxJoint = Physics.Px.D6JointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual var motionX: D6JointMotion
+        get() = D6JointMotion.fromPx(pxJoint.getMotion(PxD6AxisEnum.eX))
+        set(value) = pxJoint.setMotion(PxD6AxisEnum.eX, value.pxVal)
+
+    actual var motionY: D6JointMotion
+        get() = D6JointMotion.fromPx(pxJoint.getMotion(PxD6AxisEnum.eY))
+        set(value) = pxJoint.setMotion(PxD6AxisEnum.eY, value.pxVal)
+
+    actual var motionZ: D6JointMotion
+        get() = D6JointMotion.fromPx(pxJoint.getMotion(PxD6AxisEnum.eZ))
+        set(value) = pxJoint.setMotion(PxD6AxisEnum.eZ, value.pxVal)
+
+    actual fun setDistanceLimit(extend: Float, stiffness: Float, damping: Float) {
+        pxJoint.setDistanceLimit(PxJointLinearLimit(extend, PxSpring(stiffness, damping)))
+        //pxJoint.constraintFlags += PxD6JointDriveFlagEnum.eACCELERATION
+        pxJoint.setConstraintFlag(PxD6JointDriveFlagEnum.eACCELERATION, true)
+    }
+
+    actual fun setXLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLinearLimit(PxD6AxisEnum.eX,
+            PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        motionX = D6JointMotion.Limited
+    }
+    actual fun setYLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLinearLimit(PxD6AxisEnum.eY,
+            PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        motionY = D6JointMotion.Limited
+    }
+    actual fun setZLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLinearLimit(PxD6AxisEnum.eZ,
+            PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        motionZ = D6JointMotion.Limited
+    }
+}

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/DistanceJoint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/DistanceJoint.kt
@@ -1,0 +1,46 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.MemoryStack
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.toPxTransform
+import physx.*
+
+actual class DistanceJoint actual constructor(
+    actual val bodyA: RigidActor,
+    actual val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+
+    override val pxJoint: PxDistanceJoint
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = frameA.toPxTransform(mem.createPxTransform())
+            val frmB = frameB.toPxTransform(mem.createPxTransform())
+            pxJoint = Physics.Px.DistanceJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual fun setMaxDistance(maxDistance: Float) {
+        pxJoint.maxDistance = maxDistance
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMAX_DISTANCE_ENABLED, maxDistance >= 0f)
+    }
+    actual fun setMinDistance(minDistance: Float) {
+        pxJoint.minDistance = minDistance
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMIN_DISTANCE_ENABLED, minDistance >= 0f)
+    }
+
+    actual fun removeMaxDistance() {
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMAX_DISTANCE_ENABLED, false)
+    }
+
+    actual fun removeMinDistance() {
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMIN_DISTANCE_ENABLED, false)
+    }
+}

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/FixedJoint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/FixedJoint.kt
@@ -10,15 +10,12 @@ import physx.PxFixedJoint
 import physx.constraintFlags
 
 actual class FixedJoint actual constructor(actual val bodyA: RigidActor, actual val bodyB: RigidActor,
-                                           frameA: Mat4f, frameB: Mat4f) : Joint {
+                                           frameA: Mat4f, frameB: Mat4f) : Joint() {
 
     actual val frameA = Mat4f().set(frameA)
     actual val frameB = Mat4f().set(frameB)
 
     override val pxJoint: PxFixedJoint
-
-    override val isBroken: Boolean
-        get() = pxJoint.constraintFlags.isSet(PxConstraintFlagEnum.eBROKEN)
 
     init {
         Physics.checkIsLoaded()
@@ -28,7 +25,4 @@ actual class FixedJoint actual constructor(actual val bodyA: RigidActor, actual 
             pxJoint = Physics.Px.FixedJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
         }
     }
-
-    override fun setBreakForce(force: Float, torque: Float) = pxJoint.setBreakForce(force, torque)
-
 }

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
@@ -1,17 +1,27 @@
 package de.fabmax.kool.physics.joints
 
 import de.fabmax.kool.physics.Releasable
+import physx.PxConstraintFlagEnum
 import physx.PxJoint
+import physx.constraintFlags
 
-actual interface Joint : Releasable {
+actual abstract class Joint : Releasable {
 
-    val pxJoint: PxJoint
+    abstract val pxJoint: PxJoint
 
-    actual val isBroken: Boolean
-
-    actual fun setBreakForce(force: Float, torque: Float)
+    actual fun setBreakForce(force: Float, torque: Float) = pxJoint.setBreakForce(force, torque)
 
     override fun release() {
         pxJoint.release()
     }
+
+    actual val isBroken: Boolean
+        get() = pxJoint.constraintFlags.isSet(PxConstraintFlagEnum.eBROKEN)
+
+    actual var debugVisualize: Boolean = false
+        set(value) = if ( value ) {
+            pxJoint.constraintFlags.set(PxConstraintFlagEnum.eVISUALIZATION)
+        } else {
+            pxJoint.constraintFlags.clear(PxConstraintFlagEnum.eVISUALIZATION)
+        }
 }

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/PrismaticJoint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/PrismaticJoint.kt
@@ -1,0 +1,41 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.MemoryStack
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.toPxTransform
+import physx.PxJointLinearLimitPair
+import physx.PxPrismaticJoint
+import physx.PxPrismaticJointFlagEnum
+import physx.PxSpring
+
+actual class PrismaticJoint actual constructor(
+    val bodyA: RigidActor,
+    val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+    override val pxJoint: PxPrismaticJoint
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = posA.toPxTransform(mem.createPxTransform())
+            val frmB = posB.toPxTransform(mem.createPxTransform())
+            pxJoint = Physics.Px.PrismaticJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual fun setLimit( lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float ) {
+        pxJoint.setLimit(PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        pxJoint.setPrismaticJointFlag(PxPrismaticJointFlagEnum.eLIMIT_ENABLED, true)
+    }
+
+    actual fun removeLimit() {
+        pxJoint.setPrismaticJointFlag(PxPrismaticJointFlagEnum.eLIMIT_ENABLED, false)
+    }
+
+}

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/RevoluteJoint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/RevoluteJoint.kt
@@ -5,11 +5,12 @@ import de.fabmax.kool.math.Vec3f
 import de.fabmax.kool.physics.MemoryStack
 import de.fabmax.kool.physics.Physics
 import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.joints.CommonRevoluteJoint.Companion.computeFrame
 import de.fabmax.kool.physics.toPxTransform
 import physx.*
 
 actual class RevoluteJoint actual constructor(actual val bodyA: RigidActor, actual val bodyB: RigidActor,
-                                              frameA: Mat4f, frameB: Mat4f) : CommonRevoluteJoint(), Joint {
+                                              frameA: Mat4f, frameB: Mat4f) : Joint() {
 
 
     actual val frameA = Mat4f().set(frameA)
@@ -22,9 +23,6 @@ actual class RevoluteJoint actual constructor(actual val bodyA: RigidActor, actu
 
     override val pxJoint: PxRevoluteJoint
 
-    override val isBroken: Boolean
-        get() = pxJoint.constraintFlags.isSet(PxConstraintFlagEnum.eBROKEN)
-
     init {
         Physics.checkIsLoaded()
         MemoryStack.stackPush().use { mem ->
@@ -33,8 +31,6 @@ actual class RevoluteJoint actual constructor(actual val bodyA: RigidActor, actu
             pxJoint = Physics.Px.RevoluteJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
         }
     }
-
-    override fun setBreakForce(force: Float, torque: Float) = pxJoint.setBreakForce(force, torque)
 
     actual fun disableAngularMotor() {
         pxJoint.driveVelocity = 0f

--- a/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
+++ b/kool-physics/src/jsMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
@@ -1,0 +1,37 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.MemoryStack
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.toPxTransform
+import physx.*
+
+actual class SphericalJoint actual constructor(
+    actual val bodyA: RigidActor,
+    actual val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+    override val pxJoint: PxSphericalJoint
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = posA.toPxTransform(mem.createPxTransform())
+            val frmB = posB.toPxTransform(mem.createPxTransform())
+            pxJoint = Physics.Px.SphericalJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual fun setSoftLimitCone(yLimitAngle: Float, zLimitAngle: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLimitCone(PxJointLimitCone(yLimitAngle, zLimitAngle, PxSpring(stiffness, damping)))
+        pxJoint.setSphericalJointFlag(PxSphericalJointFlagEnum.eLIMIT_ENABLED, true)
+    }
+
+    actual fun removeLimitCone() {
+        pxJoint.setSphericalJointFlag(PxSphericalJointFlagEnum.eLIMIT_ENABLED, false)
+    }
+}

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/D6Joint.kt
@@ -1,0 +1,89 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.createPxTransform
+import de.fabmax.kool.physics.toPxTransform
+import org.lwjgl.system.MemoryStack
+import physx.PxTopLevelFunctions
+import physx.extensions.*
+import physx.physics.PxConstraintFlagEnum
+
+actual enum class D6JointMotion(val pxVal: Int) {
+    Free(PxD6MotionEnum.eFREE),
+    Limited(PxD6MotionEnum.eLIMITED),
+    Locked(PxD6MotionEnum.eLOCKED);
+
+    companion object {
+        fun fromPx(pxVal: Int) = when (pxVal) {
+            PxD6MotionEnum.eFREE -> D6JointMotion.Free
+            PxD6MotionEnum.eLIMITED -> D6JointMotion.Limited
+            PxD6MotionEnum.eLOCKED -> D6JointMotion.Locked
+            else -> throw RuntimeException()
+        }
+    }
+}
+actual class D6Joint actual constructor(
+    actual val bodyA: RigidActor,
+    actual val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+
+    actual var projectionLinearTolerance: Float? = null
+        set(value) = if ( value != null ) {
+            pxJoint.projectionLinearTolerance = value
+            pxJoint.constraintFlags.set(PxConstraintFlagEnum.ePROJECTION)
+        } else {
+            pxJoint.constraintFlags.clear(PxConstraintFlagEnum.ePROJECTION)
+        }
+
+    override val pxJoint: PxD6Joint
+
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = frameA.toPxTransform(mem.createPxTransform())
+            val frmB = frameB.toPxTransform(mem.createPxTransform())
+            pxJoint = PxTopLevelFunctions.D6JointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual var motionX: D6JointMotion
+        get() = D6JointMotion.fromPx(pxJoint.getMotion(PxD6AxisEnum.eX))
+        set(value) = pxJoint.setMotion(PxD6AxisEnum.eX, value.pxVal)
+
+    actual var motionY: D6JointMotion
+        get() = D6JointMotion.fromPx(pxJoint.getMotion(PxD6AxisEnum.eY))
+        set(value) = pxJoint.setMotion(PxD6AxisEnum.eY, value.pxVal)
+
+    actual var motionZ: D6JointMotion
+        get() = D6JointMotion.fromPx(pxJoint.getMotion(PxD6AxisEnum.eZ))
+        set(value) = pxJoint.setMotion(PxD6AxisEnum.eZ, value.pxVal)
+
+    actual fun setDistanceLimit(extend: Float, stiffness: Float, damping: Float) {
+        pxJoint.setDistanceLimit(PxJointLinearLimit(extend, PxSpring(stiffness, damping)))
+    }
+
+    actual fun setXLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLinearLimit(PxD6AxisEnum.eX,
+            PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        motionX = D6JointMotion.Limited
+    }
+
+    actual fun setYLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLinearLimit(PxD6AxisEnum.eY,
+            PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        motionY = D6JointMotion.Limited
+    }
+
+    actual fun setZLinearLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLinearLimit(PxD6AxisEnum.eZ,
+            PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        motionZ = D6JointMotion.Limited
+    }
+}

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/DistanceJoint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/DistanceJoint.kt
@@ -1,0 +1,52 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.createPxTransform
+import de.fabmax.kool.physics.toPxTransform
+import org.lwjgl.system.MemoryStack
+import physx.PxTopLevelFunctions
+import physx.extensions.PxDistanceJoint
+import physx.extensions.PxDistanceJointFlagEnum
+import physx.extensions.PxFixedJoint
+import physx.physics.PxConstraintFlagEnum
+
+actual class DistanceJoint actual constructor(
+    actual val bodyA: RigidActor,
+    actual val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+
+    override val pxJoint: PxDistanceJoint
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = frameA.toPxTransform(mem.createPxTransform())
+            val frmB = frameB.toPxTransform(mem.createPxTransform())
+            pxJoint = PxTopLevelFunctions.DistanceJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual fun setMaxDistance(maxDistance: Float) {
+        pxJoint.maxDistance = maxDistance
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMAX_DISTANCE_ENABLED, true)
+    }
+    actual fun setMinDistance(minDistance: Float) {
+        pxJoint.minDistance = minDistance
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMIN_DISTANCE_ENABLED, true)
+    }
+
+    actual fun removeMaxDistance() {
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMAX_DISTANCE_ENABLED, false)
+    }
+
+    actual fun removeMinDistance() {
+        pxJoint.setDistanceJointFlag(PxDistanceJointFlagEnum.eMIN_DISTANCE_ENABLED, false)
+    }
+
+}

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/FixedJoint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/FixedJoint.kt
@@ -11,15 +11,12 @@ import physx.extensions.PxFixedJoint
 import physx.physics.PxConstraintFlagEnum
 
 actual class FixedJoint actual constructor(actual val bodyA: RigidActor, actual val bodyB: RigidActor,
-                                           frameA: Mat4f, frameB: Mat4f) : Joint {
+                                           frameA: Mat4f, frameB: Mat4f) : Joint() {
 
     actual val frameA = Mat4f().set(frameA)
     actual val frameB = Mat4f().set(frameB)
 
     override val pxJoint: PxFixedJoint
-
-    override val isBroken: Boolean
-        get() = pxJoint.constraintFlags.isSet(PxConstraintFlagEnum.eBROKEN)
 
     init {
         Physics.checkIsLoaded()
@@ -29,7 +26,4 @@ actual class FixedJoint actual constructor(actual val bodyA: RigidActor, actual 
             pxJoint = PxTopLevelFunctions.FixedJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
         }
     }
-
-    override fun setBreakForce(force: Float, torque: Float) = pxJoint.setBreakForce(force, torque)
-
 }

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/Joint.kt
@@ -2,15 +2,23 @@ package de.fabmax.kool.physics.joints
 
 import de.fabmax.kool.physics.Releasable
 import physx.extensions.PxJoint
+import physx.physics.PxConstraintFlagEnum
 
-actual interface Joint : Releasable {
+actual abstract class Joint : Releasable {
 
-    val pxJoint: PxJoint
+    abstract val pxJoint: PxJoint
 
     actual val isBroken: Boolean
+        get() = pxJoint.constraintFlags.isSet(PxConstraintFlagEnum.eBROKEN)
 
-    actual fun setBreakForce(force: Float, torque: Float)
+    actual var debugVisualize: Boolean = false
+        set(value) = if ( value ) {
+            pxJoint.constraintFlags.set(PxConstraintFlagEnum.eVISUALIZATION)
+        } else {
+            pxJoint.constraintFlags.clear(PxConstraintFlagEnum.eVISUALIZATION)
+        }
 
+    actual fun setBreakForce(force: Float, torque: Float) = pxJoint.setBreakForce(force, torque)
     override fun release() {
         pxJoint.release()
     }

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/PrismaticJoint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/PrismaticJoint.kt
@@ -1,0 +1,39 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.createPxTransform
+import de.fabmax.kool.physics.toPxTransform
+import org.lwjgl.system.MemoryStack
+import physx.PxTopLevelFunctions
+import physx.extensions.*
+
+actual class PrismaticJoint actual constructor(
+    val bodyA: RigidActor,
+    val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+    override val pxJoint: PxPrismaticJoint
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = frameA.toPxTransform(mem.createPxTransform())
+            val frmB = frameB.toPxTransform(mem.createPxTransform())
+            pxJoint = PxTopLevelFunctions.PrismaticJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+    actual fun setLimit(lowerLimit: Float, upperLimit: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLimit(PxJointLinearLimitPair(lowerLimit, upperLimit, PxSpring(stiffness, damping)))
+        pxJoint.setPrismaticJointFlag(PxPrismaticJointFlagEnum.eLIMIT_ENABLED, true)
+    }
+
+    actual fun removeLimit() {
+        pxJoint.setPrismaticJointFlag(PxPrismaticJointFlagEnum.eLIMIT_ENABLED, false)
+    }
+}

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/RevoluteJoint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/RevoluteJoint.kt
@@ -5,6 +5,7 @@ import de.fabmax.kool.math.Vec3f
 import de.fabmax.kool.physics.Physics
 import de.fabmax.kool.physics.RigidActor
 import de.fabmax.kool.physics.createPxTransform
+import de.fabmax.kool.physics.joints.CommonRevoluteJoint.Companion.computeFrame
 import de.fabmax.kool.physics.toPxTransform
 import org.lwjgl.system.MemoryStack
 import physx.PxTopLevelFunctions
@@ -14,7 +15,7 @@ import physx.physics.PxConstraintFlagEnum
 
 @Suppress("CanBeParameter")
 actual class RevoluteJoint actual constructor(actual val bodyA: RigidActor, actual val bodyB: RigidActor,
-                                              frameA: Mat4f, frameB: Mat4f) : CommonRevoluteJoint(), Joint {
+                                              frameA: Mat4f, frameB: Mat4f) : Joint() {
 
     actual val frameA = Mat4f().set(frameA)
     actual val frameB = Mat4f().set(frameB)
@@ -26,9 +27,6 @@ actual class RevoluteJoint actual constructor(actual val bodyA: RigidActor, actu
 
     override val pxJoint: PxRevoluteJoint
 
-    override val isBroken: Boolean
-        get() = pxJoint.constraintFlags.isSet(PxConstraintFlagEnum.eBROKEN)
-
     init {
         Physics.checkIsLoaded()
         MemoryStack.stackPush().use { mem ->
@@ -37,8 +35,6 @@ actual class RevoluteJoint actual constructor(actual val bodyA: RigidActor, actu
             pxJoint = PxTopLevelFunctions.RevoluteJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
         }
     }
-
-    override fun setBreakForce(force: Float, torque: Float) = pxJoint.setBreakForce(force, torque)
 
     actual fun disableAngularMotor() {
         pxJoint.driveVelocity = 0f

--- a/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
+++ b/kool-physics/src/jvmMain/kotlin/de/fabmax/kool/physics/joints/SphericalJoint.kt
@@ -1,0 +1,44 @@
+package de.fabmax.kool.physics.joints
+
+import de.fabmax.kool.math.Mat4f
+import de.fabmax.kool.physics.Physics
+import de.fabmax.kool.physics.RigidActor
+import de.fabmax.kool.physics.createPxTransform
+import de.fabmax.kool.physics.toPxTransform
+import org.lwjgl.system.MemoryStack
+import physx.PxTopLevelFunctions
+import physx.extensions.*
+
+actual class SphericalJoint actual constructor(
+    actual val bodyA: RigidActor,
+    actual val bodyB: RigidActor,
+    posA: Mat4f,
+    posB: Mat4f
+) : Joint() {
+    actual val frameA = Mat4f().set(posA)
+    actual val frameB = Mat4f().set(posB)
+    override val pxJoint: PxSphericalJoint
+
+    init {
+        Physics.checkIsLoaded()
+        MemoryStack.stackPush().use { mem ->
+            val frmA = frameA.toPxTransform(mem.createPxTransform())
+            val frmB = frameB.toPxTransform(mem.createPxTransform())
+            pxJoint = PxTopLevelFunctions.SphericalJointCreate(Physics.physics, bodyA.pxRigidActor, frmA, bodyB.pxRigidActor, frmB)
+        }
+    }
+
+
+//    actual fun setHardLimitCone(yLimitAngle: Float, zLimitAngle: Float, contactDist: Float) {
+//        pxJoint.setLimitCone(PxJointLimitCone(yLimitAngle, zLimitAngle, contactDist))
+//    }
+
+    actual fun setSoftLimitCone(yLimitAngle: Float, zLimitAngle: Float, stiffness: Float, damping: Float) {
+        pxJoint.setLimitCone(PxJointLimitCone(yLimitAngle, zLimitAngle, PxSpring(stiffness, damping)))
+        pxJoint.setSphericalJointFlag(PxSphericalJointFlagEnum.eLIMIT_ENABLED, true)
+    }
+
+    actual fun removeLimitCone() {
+        pxJoint.setSphericalJointFlag(PxSphericalJointFlagEnum.eLIMIT_ENABLED, false)
+    }
+}


### PR DESCRIPTION
Hello, thanx for great lib.
Just adding more PhysX joint wrappers, and need for advice how to implement D6Joint interface.

As in c++ its just set of functions `setMotion(PxD6Axis, PxD6Motion)`. What would be best:
make it as set of functions like `freeMotionX`, `lockMotionX`, `freeMotionY`, `lockMotionY`...
or make public available enum wrapping `PxD6Axis` and `PxD6Motion` values and make pair of `freeMotion(Axis)`, `lockMotion(Axis)`? or just reveal `Px*` enums as arguments ?
