### PR TITLE
Add file path return value for loadFileByUser and saveFileByUser

### DIFF
--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/AssetManager.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/AssetManager.kt
@@ -106,9 +106,9 @@ abstract class AssetManager : CoroutineScope {
 
     abstract fun createFontMapData(font: AtlasFont, fontScale: Float, outMetrics: MutableMap<Char, CharMetrics>): TextureData2d
 
-    abstract suspend fun loadFileByUser(): Uint8Buffer?
+    abstract suspend fun loadFileByUser(filterList: String? = null): LoadedFile
 
-    abstract fun saveFileByUser(data: Uint8Buffer, fileName: String, mimeType: String = "application/octet-stream")
+    abstract fun saveFileByUser(data: Uint8Buffer, fileName: String, mimeType: String = "application/octet-stream"): String?
 
     protected open fun isHttpAsset(assetPath: String): Boolean =
             // maybe use something less naive here?
@@ -216,3 +216,4 @@ data class TextureAssetRef(val url: String, val isLocal: Boolean, val fmt: TexFo
 sealed class LoadedAsset(val ref: AssetRef, val successfull: Boolean)
 class LoadedRawAsset(ref: AssetRef, val data: Uint8Buffer?) : LoadedAsset(ref, data != null)
 class LoadedTextureAsset(ref: AssetRef, val data: TextureData?) : LoadedAsset(ref, data != null)
+data class LoadedFile(val path: String?, val data: Uint8Buffer?)

--- a/kool-core/src/jvmMain/kotlin/de/fabmax/kool/platform/JvmAssetManager.kt
+++ b/kool-core/src/jvmMain/kotlin/de/fabmax/kool/platform/JvmAssetManager.kt
@@ -133,15 +133,18 @@ class JvmAssetManager internal constructor(props: Lwjgl3Context.InitProps, val c
     override fun createFontMapData(font: AtlasFont, fontScale: Float, outMetrics: MutableMap<Char, CharMetrics>) =
         fontGenerator.createFontMapData(font, fontScale, outMetrics)
 
-    override suspend fun loadFileByUser(): Uint8Buffer? {
-        chooseFile()?.let { file ->
+    override suspend fun loadFileByUser(filterList: String?): LoadedFile {
+        chooseFile(filterList)?.let { file ->
             try {
-                return Uint8BufferImpl(file.readBytes())
+                return LoadedFile(
+                    file.absolutePath,
+                    Uint8BufferImpl(file.readBytes())
+                )
             } catch (e: IOException) {
                 e.printStackTrace()
             }
         }
-        return null
+        return LoadedFile(null, null)
     }
 
     fun chooseFile(filterList: String? = null): File? {
@@ -155,7 +158,7 @@ class JvmAssetManager internal constructor(props: Lwjgl3Context.InitProps, val c
         return null
     }
 
-    override fun saveFileByUser(data: Uint8Buffer, fileName: String, mimeType: String) {
+    override fun saveFileByUser(data: Uint8Buffer, fileName: String, mimeType: String): String? {
         val outPath = PointerBuffer.allocateDirect(1)
         val result = NativeFileDialog.NFD_SaveDialog(null, fileChooserPath, outPath)
         if (result == NativeFileDialog.NFD_OKAY) {
@@ -167,7 +170,11 @@ class JvmAssetManager internal constructor(props: Lwjgl3Context.InitProps, val c
             } catch (e: IOException) {
                 e.printStackTrace()
             }
+
+            return file.absolutePath
         }
+
+        return null
     }
 
     override suspend fun loadTextureData2d(imagePath: String, format: TexFormat?): TextureData2d {


### PR DESCRIPTION
This returns a path for the JVM version of loadFileByUser in the form of the LoadedFile class. In JS all path properties are null. With saveFileByUser now a string? is returned which returns the savePath and null for JS.

Additionally, on the loadFileByUser function, the filterList property has been exposed which is used by the fileChooser.