### PR TITLE
Allow null in remember and make sure item index is never negative

### DIFF
--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ui2/LazyList.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ui2/LazyList.kt
@@ -3,6 +3,7 @@ package de.fabmax.kool.modules.ui2
 import de.fabmax.kool.KoolContext
 import de.fabmax.kool.math.MutableVec2f
 import de.fabmax.kool.math.clamp
+import de.fabmax.kool.math.max
 import de.fabmax.kool.util.Color
 import de.fabmax.kool.util.logE
 import kotlin.math.abs
@@ -167,7 +168,7 @@ open class LazyListNode(parent: UiNode?, surface: UiSurface) : UiNode(parent, su
         padPrevItems.clear()
         padPrevItems += prevItems
         prevItems.clear()
-        var itemI = insertNewItemsBefore(insertBeforeItems)
+        var itemI = max(0, insertNewItemsBefore(insertBeforeItems))
 
         // pad oldChildren
         oldChildren.clear()

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ui2/UiScope.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ui2/UiScope.kt
@@ -52,7 +52,8 @@ inline fun UiScope.Popup(
 }
 
 inline fun <reified T: Any> UiScope.remember(provider: () -> T): T = uiNode.weakMemory.weakMemory(provider)
-fun <T: Any> UiScope.remember(initialState: T): MutableStateValue<T> = uiNode.weakMemory.weakMemory { mutableStateOf(initialState) }
+fun <T: Any?> UiScope.remember(initialState: T): MutableStateValue<T> = uiNode.weakMemory.weakMemory { mutableStateOf(initialState) }
+fun <T: Any?> UiScope.remember(initialState: T, onChange: (T) -> Unit) = uiNode.weakMemory.weakMemory { mutableStateOf(initialState).onChange(onChange) }
 fun UiScope.rememberScrollState(): ScrollState = uiNode.weakMemory.weakMemory { ScrollState() }
 fun UiScope.rememberListState(): LazyListState = uiNode.weakMemory.weakMemory { LazyListState() }
 fun UiScope.clearMemory() = uiNode.weakMemory.clear()


### PR DESCRIPTION
- Ensures that the item index in the LazyList is never negative
- Adds an additional `remember` override to allow specifying an on change event
- Allows the use of null values as initial values and types in `remember`