### PR TITLE
Added isJsCanvasToWindowFitting to KoolConfig. 

### DIFF
--- a/kool-core/src/jsMain/kotlin/de/fabmax/kool/KoolConfig.kt
+++ b/kool-core/src/jsMain/kotlin/de/fabmax/kool/KoolConfig.kt
@@ -5,6 +5,7 @@ actual data class KoolConfig(
 
     val canvasName: String = "glCanvas",
     val isGlobalKeyEventGrabbing: Boolean = true,
+    val isJsCanvasToWindowFitting: Boolean = true,
 
     val customTtfFonts: Map<String, String> = emptyMap(),
 )

--- a/kool-core/src/jsMain/kotlin/de/fabmax/kool/platform/JsContext.kt
+++ b/kool-core/src/jsMain/kotlin/de/fabmax/kool/platform/JsContext.kt
@@ -72,10 +72,12 @@ class JsContext internal constructor() : KoolContext() {
         canvas = document.getElementById(KoolSystem.config.canvasName) as? HTMLCanvasElement ?:
                 throw IllegalStateException("canvas element not found! Add a canvas with id \"${KoolSystem.config.canvasName}\" to your html.")
 
-        canvas.style.width = "100%"
-        canvas.style.height = "100%"
-        canvas.width = (window.innerWidth * window.devicePixelRatio).toInt()
-        canvas.height = (window.innerHeight * window.devicePixelRatio).toInt()
+        if(KoolSystem.config.isJsCanvasToWindowFitting) {
+            canvas.style.width = "100%"
+            canvas.style.height = "100%"
+            canvas.width = (window.innerWidth * window.devicePixelRatio).toInt()
+            canvas.height = (window.innerHeight * window.devicePixelRatio).toInt()
+        }
 
         // try to get a WebGL2 context first and use WebGL version 1 as fallback
         var webGlCtx = canvas.getContext("webgl2")
@@ -163,14 +165,16 @@ class JsContext internal constructor() : KoolContext() {
         val dt = (time - animationMillis) / 1000.0
         animationMillis = time
 
-        // update viewport size
-        windowScale = window.devicePixelRatio.toFloat()
-        windowWidth = (window.innerWidth * window.devicePixelRatio).toInt()
-        windowHeight = (window.innerHeight * window.devicePixelRatio).toInt()
-        if (windowWidth != canvas.width || windowHeight!= canvas.height) {
-            // resize canvas to viewport
-            canvas.width = windowWidth
-            canvas.height = windowHeight
+        if (KoolSystem.config.isJsCanvasToWindowFitting) {
+            // update viewport size
+            windowScale = window.devicePixelRatio.toFloat()
+            windowWidth = (window.innerWidth * window.devicePixelRatio).toInt()
+            windowHeight = (window.innerHeight * window.devicePixelRatio).toInt()
+            if (windowWidth != canvas.width || windowHeight != canvas.height) {
+                // resize canvas to viewport
+                canvas.width = windowWidth
+                canvas.height = windowHeight
+            }
         }
 
         // render frame

--- a/kool-core/src/jsMain/kotlin/de/fabmax/kool/platform/JsContext.kt
+++ b/kool-core/src/jsMain/kotlin/de/fabmax/kool/platform/JsContext.kt
@@ -30,6 +30,7 @@ import org.w3c.dom.ImageData
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.UIEvent
 import org.w3c.files.get
+import kotlin.math.roundToInt
 
 /**
  * @author fabmax
@@ -68,15 +69,26 @@ class JsContext internal constructor() : KoolContext() {
     private val openRenderPasses = mutableListOf<OffscreenRenderPass>()
     private val doneRenderPasses = mutableSetOf<OffscreenRenderPass>()
 
+    private var canvasFixedWidth = -1
+    private var canvasFixedHeight = -1
+
     init {
         canvas = document.getElementById(KoolSystem.config.canvasName) as? HTMLCanvasElement ?:
                 throw IllegalStateException("canvas element not found! Add a canvas with id \"${KoolSystem.config.canvasName}\" to your html.")
 
-        if(KoolSystem.config.isJsCanvasToWindowFitting) {
+        // set canvas style to desired size so that render resolution can be set according to window scale
+        if (KoolSystem.config.isJsCanvasToWindowFitting) {
             canvas.style.width = "100%"
             canvas.style.height = "100%"
             canvas.width = (window.innerWidth * window.devicePixelRatio).toInt()
             canvas.height = (window.innerHeight * window.devicePixelRatio).toInt()
+        } else {
+            canvasFixedWidth = canvas.width
+            canvasFixedHeight = canvas.height
+            canvas.style.width = "${canvasFixedWidth}px"
+            canvas.style.height = "${canvasFixedHeight}px"
+            canvas.width = (canvasFixedWidth * window.devicePixelRatio).roundToInt()
+            canvas.height = (canvasFixedHeight * window.devicePixelRatio).roundToInt()
         }
 
         // try to get a WebGL2 context first and use WebGL version 1 as fallback
@@ -165,16 +177,20 @@ class JsContext internal constructor() : KoolContext() {
         val dt = (time - animationMillis) / 1000.0
         animationMillis = time
 
+        // update viewport size according to window scale
+        windowScale = window.devicePixelRatio.toFloat()
         if (KoolSystem.config.isJsCanvasToWindowFitting) {
-            // update viewport size
-            windowScale = window.devicePixelRatio.toFloat()
             windowWidth = (window.innerWidth * window.devicePixelRatio).toInt()
             windowHeight = (window.innerHeight * window.devicePixelRatio).toInt()
-            if (windowWidth != canvas.width || windowHeight != canvas.height) {
-                // resize canvas to viewport
-                canvas.width = windowWidth
-                canvas.height = windowHeight
-            }
+        } else {
+            windowWidth = (canvasFixedWidth * window.devicePixelRatio).toInt()
+            windowHeight = (canvasFixedHeight * window.devicePixelRatio).toInt()
+        }
+        if (windowWidth != canvas.width || windowHeight != canvas.height) {
+            // resize canvas to viewport, this only affects the render resolution, actual canvas size is determined
+            // by canvas.style.width / canvas.style.height set on init
+            canvas.width = windowWidth
+            canvas.height = windowHeight
         }
 
         // render frame


### PR DESCRIPTION
The setting defaults to true. When enabled implements the current functionality which is to resize the canvas to the window size of the browser. This functionality is disabled if set to false. This is so to allow usage of Kool within the context of a website.