### PR TITLE
Add Quat.fuzzyEqualRotation

### DIFF
--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/math/Quat.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/math/Quat.kt
@@ -155,6 +155,14 @@ open class QuatF(open val x: Float, open val y: Float, open val z: Float, open v
     fun isFuzzyEqual(that: QuatF, eps: Float = FUZZY_EQ_F): Boolean =
         isFuzzyEqual(x, that.x, eps) && isFuzzyEqual(y, that.y, eps) && isFuzzyEqual(z, that.z, eps) && isFuzzyEqual(w, that.w, eps)
 
+    /**
+     * Checks equality of rotations, represented by quaternions.
+     * Quaternion, multiplied by -1, represents the same rotation, while all components have opposite signs.
+     */
+    fun isFuzzyEqualRotation(that: QuatF, eps: Float = FUZZY_EQ_F): Boolean =
+        isFuzzyEqual(that, eps) ||
+                (isFuzzyEqual(-x, that.x, eps) && isFuzzyEqual(-y, that.y, eps) && isFuzzyEqual(-z, that.z, eps) && isFuzzyEqual(-w, that.w, eps))
+
     override fun toString(): String = "($x, $y, $z, $w)"
 
     /**
@@ -495,6 +503,14 @@ open class QuatD(open val x: Double, open val y: Double, open val z: Double, ope
      */
     fun isFuzzyEqual(that: QuatD, eps: Double = FUZZY_EQ_D): Boolean =
         isFuzzyEqual(x, that.x, eps) && isFuzzyEqual(y, that.y, eps) && isFuzzyEqual(z, that.z, eps) && isFuzzyEqual(w, that.w, eps)
+
+    /**
+     * Checks equality of rotations, represented by quaternions.
+     * Quaternion, multiplied by -1, represents the same rotation, while all components have opposite signs.
+     */
+    fun isFuzzyEqualRotation(that: QuatD, eps: Double = FUZZY_EQ_D): Boolean =
+        isFuzzyEqual(that, eps) ||
+                (isFuzzyEqual(-x, that.x, eps) && isFuzzyEqual(-y, that.y, eps) && isFuzzyEqual(-z, that.z, eps) && isFuzzyEqual(-w, that.w, eps))
 
     override fun toString(): String = "($x, $y, $z, $w)"
 

--- a/kool-core/src/desktopTest/kotlin/de/fabmax/kool/math/QuatTest.kt
+++ b/kool-core/src/desktopTest/kotlin/de/fabmax/kool/math/QuatTest.kt
@@ -1,0 +1,19 @@
+package de.fabmax.kool.math
+
+import kotlin.test.Test
+
+class QuatTest {
+
+    @Test
+    fun fuzzyEqualRotation() {
+        val q = QuatD(1.0, 2.0, 3.0, 4.0).normed()
+        val minusQ = q * -1.0
+
+        assert(q.isFuzzyEqualRotation(minusQ))
+
+        val m1 = Mat3d.rotation(q)
+        val m2 = Mat3d.rotation(minusQ)
+
+        assert(m1.isFuzzyEqual(m2))
+    }
+}


### PR DESCRIPTION
Initially I thought about changing fuzzyEqual. But I figured out that this will requite to change equal and hashCode implementation to respect "equality by rotation" and code becomes really complex.

So I decided to make it as separate method instead.