### PR TITLE
Fix incorrect vertex position in ColorWheelNode

### DIFF
--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ui2/ColorWheel.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ui2/ColorWheel.kt
@@ -223,7 +223,7 @@ open class ColorWheelNode(parent: UiNode?, surface: UiSurface) : UiNode(parent, 
                     it.position.set(cos(a) * ro, sin(a) * ro, 0f)
                 }
                 val vi4 = vertex {
-                    it.position.set(cos(a) * ro, sin(a) * ro, 0f)
+                    it.position.set(cos(a) * ri, sin(a) * ri, 0f)
                 }
                 if (i > 0) {
                     addTriIndices(vi1, vi2, vi4)


### PR DESCRIPTION
Corrects the position of a vertex in the ColorWheelNode mesh generation from using the outer radius (ro) to the inner radius (ri), ensuring the geometry is constructed as intended.