### PR TITLE
Added KoolEditorConfig to allow custom appMainClass

### DIFF
--- a/kool-editor/src/commonMain/kotlin/de/fabmax/kool/editor/KoolEditorConfig.kt
+++ b/kool-editor/src/commonMain/kotlin/de/fabmax/kool/editor/KoolEditorConfig.kt
@@ -1,0 +1,3 @@
+package de.fabmax.kool.editor
+
+data class KoolEditorConfig(val projectRoot: String, val appMainClass: String = "de.fabmax.kool.app.App")

--- a/kool-editor/src/commonMain/kotlin/de/fabmax/kool/editor/ProjectFiles.kt
+++ b/kool-editor/src/commonMain/kotlin/de/fabmax/kool/editor/ProjectFiles.kt
@@ -7,7 +7,7 @@ import de.fabmax.kool.modules.filesystem.getOrCreateFile
 
 class ProjectFiles(
     val fileSystem: WritableFileSystem,
-    val appMainClass: String = "de.fabmax.kool.app.App"
+    val appMainClass: String
 ) {
     val projectModelDir = fileSystem.getOrCreateDirectories("src/commonMain/koolProject")
     val assets = fileSystem.getOrCreateDirectories("src/commonMain/resources/assets")

--- a/kool-editor/src/desktopMain/kotlin/de/fabmax/kool/editor/PlatformFunctions.desktop.kt
+++ b/kool-editor/src/desktopMain/kotlin/de/fabmax/kool/editor/PlatformFunctions.desktop.kt
@@ -128,11 +128,13 @@ actual object PlatformFunctions {
     }
 }
 
-fun KoolEditor(projectRoot: String, ctx: KoolContext): KoolEditor {
+fun KoolEditor(projectRoot: String, ctx: KoolContext): KoolEditor = KoolEditor(KoolEditorConfig(projectRoot), ctx)
+
+fun KoolEditor(koolEditorConfig: KoolEditorConfig, ctx: KoolContext): KoolEditor {
     return runBlocking {
-        val rootPath = Path(projectRoot)
+        val rootPath = Path(koolEditorConfig.projectRoot)
         if (rootPath.notExists()) {
-            logW { "Project root path does not exist, creating: $projectRoot" }
+            logW { "Project root path does not exist, creating: ${koolEditorConfig.projectRoot}" }
             rootPath.createDirectories()
         }
         val fs = PhysicalFileSystem(
@@ -149,7 +151,7 @@ fun KoolEditor(projectRoot: String, ctx: KoolContext): KoolEditor {
             ),
             isLaunchWatchService = true
         )
-        val projFiles = ProjectFiles(fs)
+        val projFiles = ProjectFiles(fs, koolEditorConfig.appMainClass)
         KoolEditor(projFiles, ctx)
     }
 }


### PR DESCRIPTION
This is a small change with the purpose of allowing the customization of [`appMainClass` in `ProjectFiles.kt`](https://github.com/kool-engine/kool/blob/792cf44ed9e35161b0b780d85b9032bc2690be38/kool-editor/src/commonMain/kotlin/de/fabmax/kool/editor/ProjectFiles.kt#L10), but I'll describe it a bit more formally below:

Currently the KoolEditor has a hardcoded value in `ProjectFiles` for the `appMainClass` set to `de.fabmax.kool.app.App`.

This makes sense for the Kool project itself (as package naming is controlled), but less so for custom projects that want to make use of the editor. Running the editor in these projects will cause errors in the editor *unless* they copy the package & class naming `de.fabmax.kool.app.App`, however there should not be a requirement for custom projects to follow the same package naming. (ie.: They might want to use `xyz.mycompany.myapp.mypackage.App` )

To allow users to specify their own appMainClass, I figured creating a KoolEditorConfig could be helpful. This would be in line with KoolApplication (which takes a KoolConfig object). I also believe that in the future more features could be added to the config. (For specifying paths and/or configuring editor features)

What this pullrequest does is the following:

* Adds a KoolEditorConfig class that allows specifying a projectRoot, and appMainClass.
* Ensures compatibility and same behaviour with existing projects.