### PR TITLE
Prevent AudioClip from automatically starting to play on desktop when enabling looping

### DIFF
--- a/kool-core/src/desktopMain/kotlin/de/fabmax/kool/modules/audio/AudioClipImpl.kt
+++ b/kool-core/src/desktopMain/kotlin/de/fabmax/kool/modules/audio/AudioClipImpl.kt
@@ -125,6 +125,7 @@ class AudioClipImpl(private val audioData: ByteArray, private val format: String
                 field = value
                 if (value) {
                     clip?.loop(Clip.LOOP_CONTINUOUSLY)
+                    if (clipState == ClipState.STOPPED) clip?.stop()
                 }
             }
 


### PR DESCRIPTION
AudioClips on desktop currently auto-start when looping is enabled. I'm assuming this is not intended as it feels very strange that this would start the audio clip:
```kotlin
audioClip.loop = true
```